### PR TITLE
Wrangler generate accept a branch option for the template repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ You have many options to install wrangler!
 
 We strongly recommend you install `npm` with a Node version manager like [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating), which puts the global `node_modules` in your home directory to eliminate permissions issues with `npm install -g`. Distribution-packaged `npm` installs often use `/usr/lib/node_modules` (which is root) for globally installed `npm` packages, and running `npm install -g` as `root` prevents `wrangler` from installing properly.
 
-
 Once you've installed `nvm` and configured your system to use the `nvm` managed node install, run:
 
 ```bash
@@ -74,108 +73,108 @@ $ wrangler publish
 
 ### 👯 `generate`
 
-  Scaffold a project, including boilerplate code for a Rust library and a Cloudflare Worker.
+Scaffold a project, including boilerplate code for a Rust library and a Cloudflare Worker.
 
-  ```bash
-  wrangler generate <name> <template> --type=["webpack", "javascript", "rust"]
-  ```
+```bash
+wrangler generate <name> <template> --branch=<branch> --type=["webpack", "javascript", "rust"]
+```
 
-  All of the arguments and flags to this command are optional:
+All of the arguments and flags to this command are optional:
 
-  - `name`: defaults to `worker`
-  - `template`: defaults to the [`https://github.com/cloudflare/worker-template`](https://github.com/cloudflare/worker-template)
-  - `type`: defaults to `javascript` based on the ["worker-template"](https://github.com/cloudflare/worker-template/blob/master/wrangler.toml)
+- `name`: defaults to `worker`
+- `template`: defaults to the [`https://github.com/cloudflare/worker-template`](https://github.com/cloudflare/worker-template)
+- `type`: defaults to `javascript` based on the ["worker-template"](https://github.com/cloudflare/worker-template/blob/master/wrangler.toml)
+- `branch`: defaults to `master`
 
 ### 📥 `init`
 
-  Creates a skeleton `wrangler.toml` in an existing directory. This can be used as an alternative to `generate` if you prefer to clone a repository yourself.
+Creates a skeleton `wrangler.toml` in an existing directory. This can be used as an alternative to `generate` if you prefer to clone a repository yourself.
 
-  ```bash
-  wrangler init <name> --type=["webpack", "javascript", "rust"]
-  ```
+```bash
+wrangler init <name> --type=["webpack", "javascript", "rust"]
+```
 
-  All of the arguments and flags to this command are optional:
+All of the arguments and flags to this command are optional:
 
-  - `name`: defaults to the name of your working directory
-  - `type`: defaults to ["webpack"](https://developers.cloudflare.com/workers/tooling/wrangler/webpack).
+- `name`: defaults to the name of your working directory
+- `type`: defaults to ["webpack"](https://developers.cloudflare.com/workers/tooling/wrangler/webpack).
 
 ### 🦀⚙️ `build`
 
-  Build your project. This command looks at your `wrangler.toml` file and runs the build steps associated
-  with the `"type"` declared there.
+Build your project. This command looks at your `wrangler.toml` file and runs the build steps associated
+with the `"type"` declared there.
 
-  Additionally, you can configure different [environments](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/environments).
-
+Additionally, you can configure different [environments](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/environments).
 
 ### 🔓 `login`
 
-  Authenticate Wrangler with your Cloudflare login. This will prompt you with a Cloudflare account login page and is the alternative to `wrangler config`.
+Authenticate Wrangler with your Cloudflare login. This will prompt you with a Cloudflare account login page and is the alternative to `wrangler config`.
 
 ### 🔧 `config`
 
-  Authenticate Wrangler with a Cloudflare API Token. This is an interactive command that will prompt you for your API token:
+Authenticate Wrangler with a Cloudflare API Token. This is an interactive command that will prompt you for your API token:
 
-  ```bash
-  wrangler config
-  Enter API token:
-  superlongapitoken
-  ```
+```bash
+wrangler config
+Enter API token:
+superlongapitoken
+```
 
-  You can also provide your email and global API key (this is not recommended for security reasons):
+You can also provide your email and global API key (this is not recommended for security reasons):
 
-  ```bash
-  wrangler config --api-key
-  Enter email:
-  testuser@example.com
-  Enter global API key:
-  superlongapikey
-  ```
+```bash
+wrangler config --api-key
+Enter email:
+testuser@example.com
+Enter global API key:
+superlongapikey
+```
 
-  You can also [use environment variables](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/) to configure these values.
+You can also [use environment variables](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/) to configure these values.
 
 ### ☁️ 🆙 `publish`
 
-  Publish your Worker to Cloudflare. Several keys in your `wrangler.toml` determine whether you are publishing to a workers.dev subdomain or your own registered domain, proxied through Cloudflare.
+Publish your Worker to Cloudflare. Several keys in your `wrangler.toml` determine whether you are publishing to a workers.dev subdomain or your own registered domain, proxied through Cloudflare.
 
-  Additionally, you can configure different [environments](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/environments).
+Additionally, you can configure different [environments](https://developers.cloudflare.com/workers/tooling/wrangler/configuration/environments).
 
-  You can also use environment variables to handle authentication when you publish a Worker.
+You can also use environment variables to handle authentication when you publish a Worker.
 
-  ```bash
-  # e.g.
-  CF_API_TOKEN=superlongtoken wrangler publish
-  # where
-  # $CF_API_TOKEN -> your Cloudflare API token
+```bash
+# e.g.
+CF_API_TOKEN=superlongtoken wrangler publish
+# where
+# $CF_API_TOKEN -> your Cloudflare API token
 
-  CF_API_KEY=superlongapikey CF_EMAIL=testuser@example.com wrangler publish
-  # where
-  # $CF_API_KEY -> your Cloudflare API key
-  # $CF_EMAIL -> your Cloudflare account email
-  ```
+CF_API_KEY=superlongapikey CF_EMAIL=testuser@example.com wrangler publish
+# where
+# $CF_API_KEY -> your Cloudflare API key
+# $CF_EMAIL -> your Cloudflare account email
+```
 
 ### 🗂 `kv`
 
-  Interact with your Workers KV store. This is actually a whole suite of subcommands. Read more about in [Wrangler KV Documentation](https://developers.cloudflare.com/workers/tooling/wrangler/kv_commands).
+Interact with your Workers KV store. This is actually a whole suite of subcommands. Read more about in [Wrangler KV Documentation](https://developers.cloudflare.com/workers/tooling/wrangler/kv_commands).
 
 ### 👂 `dev`
 
-  `wrangler dev` works very similarly to `wrangler preview` except that instead of opening your browser to preview your worker, it will start a server on localhost that will execute your worker on incoming HTTP requests. From there you can use cURL, Postman, your browser, or any other HTTP client to test the behavior of your worker before publishing it.
+`wrangler dev` works very similarly to `wrangler preview` except that instead of opening your browser to preview your worker, it will start a server on localhost that will execute your worker on incoming HTTP requests. From there you can use cURL, Postman, your browser, or any other HTTP client to test the behavior of your worker before publishing it.
 
-  You should run wrangler dev from your worker directory, and if your worker makes any requests to a backend, you should specify the host with `--host example.com`.
+You should run wrangler dev from your worker directory, and if your worker makes any requests to a backend, you should specify the host with `--host example.com`.
 
-  From here you should be able to send HTTP requests to `localhost:8787` along with any headers and paths, and your worker should execute as expected. Additionally, you should see console.log messages and exceptions appearing in your terminal.
+From here you should be able to send HTTP requests to `localhost:8787` along with any headers and paths, and your worker should execute as expected. Additionally, you should see console.log messages and exceptions appearing in your terminal.
 
-  ```bash
+```bash
 👂 Listening on http://localhost:8787
-  [2020-02-18 19:37:08] GET example.com/ HTTP/1.1 200 OK
-  ```
+[2020-02-18 19:37:08] GET example.com/ HTTP/1.1 200 OK
+```
 
-  All of the arguments and flags to this command are optional:
+All of the arguments and flags to this command are optional:
 
-  - `env`: environment to build
-  - `host`: domain to test behind your worker. defaults to example.com
-  - `ip`: ip to listen on. defaults to localhost
-  - `port`: port to listen on. defaults to 8787
+- `env`: environment to build
+- `host`: domain to test behind your worker. defaults to example.com
+- `ip`: ip to listen on. defaults to localhost
+- `port`: port to listen on. defaults to 8787
 
 ## Additional Documentation
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -10,7 +10,7 @@ use crate::{commands, install};
 pub fn generate(
     name: &str,
     template: &str,
-    template_branch: &str,
+    branch: Option<&str>,
     target_type: Option<TargetType>,
     site: bool,
 ) -> Result<(), failure::Error> {
@@ -32,7 +32,7 @@ pub fn generate(
     };
 
     log::info!("Generating a new worker project with name '{}'", new_name);
-    run_generate(&new_name, template, template_branch)?;
+    run_generate(&new_name, template, branch)?;
 
     let config_path = PathBuf::from("./").join(&name);
     // TODO: this is tightly coupled to our site template. Need to remove once
@@ -50,20 +50,18 @@ pub fn generate(
 pub fn run_generate(
     name: &str,
     template: &str,
-    template_branch: &str,
+    optional_branch: Option<&str>,
 ) -> Result<(), failure::Error> {
     let binary_path = install::install_cargo_generate()?;
-
-    let args = [
-        "generate",
-        "--git",
-        template,
-        "--branch",
-        template_branch,
-        "--name",
-        name,
-        "--force",
-    ];
+    let args = if let Some(branch) = optional_branch {
+        [
+            "generate", "--git", template, "--branch", branch, "--name", name, "--force",
+        ]
+    } else {
+        [
+            "generate", "--git", template, "", "", "--name", name, "--force",
+        ]
+    };
 
     let command = command(binary_path, &args);
     let command_name = format!("{:?}", command);

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -10,6 +10,7 @@ use crate::{commands, install};
 pub fn generate(
     name: &str,
     template: &str,
+    template_branch: &str,
     target_type: Option<TargetType>,
     site: bool,
 ) -> Result<(), failure::Error> {
@@ -31,7 +32,7 @@ pub fn generate(
     };
 
     log::info!("Generating a new worker project with name '{}'", new_name);
-    run_generate(&new_name, template)?;
+    run_generate(&new_name, template, template_branch)?;
 
     let config_path = PathBuf::from("./").join(&name);
     // TODO: this is tightly coupled to our site template. Need to remove once
@@ -46,10 +47,23 @@ pub fn generate(
     Ok(())
 }
 
-pub fn run_generate(name: &str, template: &str) -> Result<(), failure::Error> {
+pub fn run_generate(
+    name: &str,
+    template: &str,
+    template_branch: &str,
+) -> Result<(), failure::Error> {
     let binary_path = install::install_cargo_generate()?;
 
-    let args = ["generate", "--git", template, "--name", name, "--force"];
+    let args = [
+        "generate",
+        "--git",
+        template,
+        "--branch",
+        template_branch,
+        "--name",
+        name,
+        "--force",
+    ];
 
     let command = command(binary_path, &args);
     let command_name = format!("{:?}", command);

--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,2 @@
 pub const WASM_PACK_VERSION: &str = "0.9.1";
-pub const GENERATE_VERSION: &str = "0.5.0";
+pub const GENERATE_VERSION: &str = "0.5.1";

--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,2 @@
 pub const WASM_PACK_VERSION: &str = "0.9.1";
-pub const GENERATE_VERSION: &str = "0.5.3";
+pub const GENERATE_VERSION: &str = "0.5.1";

--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,2 @@
 pub const WASM_PACK_VERSION: &str = "0.9.1";
-pub const GENERATE_VERSION: &str = "0.5.1";
+pub const GENERATE_VERSION: &str = "0.5.3";

--- a/src/install/dependencies.rs
+++ b/src/install/dependencies.rs
@@ -1,2 +1,2 @@
 pub const WASM_PACK_VERSION: &str = "0.9.1";
-pub const GENERATE_VERSION: &str = "0.5.1";
+pub const GENERATE_VERSION: &str = "0.6.0";

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,13 @@ fn run() -> Result<(), failure::Error> {
                         .index(2),
                 )
                 .arg(
+                    Arg::with_name("branch")
+                        .short("b")
+                        .long("branch")
+                        .takes_value(true)
+                        .help("the git branch of the template repository. Defaults to master."),
+                )
+                .arg(
                     Arg::with_name("type")
                         .short("t")
                         .long("type")
@@ -682,6 +689,7 @@ fn run() -> Result<(), failure::Error> {
         let name = matches.value_of("name").unwrap_or("worker");
         let site = matches.is_present("site");
         let template = matches.value_of("template");
+        let template_branch = matches.value_of("branch").unwrap_or("master");
         let mut target_type = None;
 
         let template = if site {
@@ -710,7 +718,7 @@ fn run() -> Result<(), failure::Error> {
             name
         );
 
-        commands::generate(name, template, target_type, site)?;
+        commands::generate(name, template, template_branch, target_type, site)?;
     } else if let Some(matches) = matches.subcommand_matches("init") {
         let name = matches.value_of("name");
         let site = matches.is_present("site");

--- a/src/main.rs
+++ b/src/main.rs
@@ -399,7 +399,7 @@ fn run() -> Result<(), failure::Error> {
                         .short("b")
                         .long("branch")
                         .takes_value(true)
-                        .help("the git branch of the template repository. Defaults to master."),
+                        .help("the git branch of the template repository you wish to checkout."),
                 )
                 .arg(
                     Arg::with_name("type")
@@ -689,7 +689,7 @@ fn run() -> Result<(), failure::Error> {
         let name = matches.value_of("name").unwrap_or("worker");
         let site = matches.is_present("site");
         let template = matches.value_of("template");
-        let template_branch = matches.value_of("branch").unwrap_or("master");
+        let branch = matches.value_of("branch");
         let mut target_type = None;
 
         let template = if site {
@@ -718,7 +718,7 @@ fn run() -> Result<(), failure::Error> {
             name
         );
 
-        commands::generate(name, template, template_branch, target_type, site)?;
+        commands::generate(name, template, branch, target_type, site)?;
     } else if let Some(matches) = matches.subcommand_matches("init") {
         let name = matches.value_of("name");
         let site = matches.is_present("site");

--- a/src/settings/toml/site.rs
+++ b/src/settings/toml/site.rs
@@ -41,10 +41,15 @@ impl Site {
     pub fn scaffold_worker(&self) -> Result<(), failure::Error> {
         let entry_point = &self.entry_point()?;
         let template = "https://github.com/cloudflare/worker-sites-init";
+        let template_branch = "master";
 
         if !entry_point.exists() {
             log::info!("Generating a new workers site project");
-            run_generate(entry_point.file_name().unwrap().to_str().unwrap(), template)?;
+            run_generate(
+                entry_point.file_name().unwrap().to_str().unwrap(),
+                template,
+                template_branch,
+            )?;
 
             // This step is to prevent having a git repo within a git repo after
             // generating the scaffold into an existing project.

--- a/src/settings/toml/site.rs
+++ b/src/settings/toml/site.rs
@@ -41,14 +41,13 @@ impl Site {
     pub fn scaffold_worker(&self) -> Result<(), failure::Error> {
         let entry_point = &self.entry_point()?;
         let template = "https://github.com/cloudflare/worker-sites-init";
-        let template_branch = "master";
 
         if !entry_point.exists() {
             log::info!("Generating a new workers site project");
             run_generate(
                 entry_point.file_name().unwrap().to_str().unwrap(),
                 template,
-                template_branch,
+                None,
             )?;
 
             // This step is to prevent having a git repo within a git repo after

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 #[test]
 fn it_generates_with_defaults() {
     let name = "worker";
-    generate(None, None, None);
+    generate(None, None, None, None);
 
     assert_eq!(Path::new(name).exists(), true);
 
@@ -20,8 +20,14 @@ fn it_generates_with_defaults() {
 fn it_generates_with_arguments() {
     let name = "example";
     let template = "https://github.com/cloudflare/rustwasm-worker-template";
+    let template_branch = "master";
     let project_type = "webpack";
-    generate(Some(name), Some(template), Some(project_type));
+    generate(
+        Some(name),
+        Some(template),
+        Some(template_branch),
+        Some(project_type),
+    );
 
     assert_eq!(Path::new(name).exists(), true);
 
@@ -32,15 +38,26 @@ fn it_generates_with_arguments() {
     cleanup(name);
 }
 
-pub fn generate(name: Option<&str>, template: Option<&str>, project_type: Option<&str>) {
+pub fn generate(
+    name: Option<&str>,
+    template: Option<&str>,
+    template_branch: Option<&str>,
+    project_type: Option<&str>,
+) {
     let mut wrangler = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-    if name.is_none() && template.is_none() && project_type.is_none() {
+    if name.is_none() && template.is_none() && template_branch.is_none() && project_type.is_none() {
         wrangler.arg("generate").assert().success();
-    } else if name.is_some() && template.is_some() && project_type.is_some() {
+    } else if name.is_some()
+        && template.is_some()
+        && template_branch.is_some()
+        && project_type.is_some()
+    {
         wrangler
             .arg("generate")
             .arg(name.unwrap())
             .arg(template.unwrap())
+            .arg("--branch")
+            .arg(template_branch.unwrap())
             .arg("--type")
             .arg(project_type.unwrap())
             .assert()

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -36,14 +36,9 @@ fn it_generates_with_some_arguments() {
 fn it_generates_with_all_arguments() {
     let name = "example-branch";
     let template = "p-j/worker-eapi-template";
-    let template_branch = "main";
+    let branch = "main";
     let project_type = "webpack";
-    generate(
-        Some(name),
-        Some(template),
-        Some(template_branch),
-        Some(project_type),
-    );
+    generate(Some(name), Some(template), Some(branch), Some(project_type));
 
     assert_eq!(Path::new(name).exists(), true);
 
@@ -57,34 +52,26 @@ fn it_generates_with_all_arguments() {
 pub fn generate(
     name: Option<&str>,
     template: Option<&str>,
-    template_branch: Option<&str>,
+    branch: Option<&str>,
     project_type: Option<&str>,
 ) {
     let mut wrangler = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-    if name.is_none() && template.is_none() && template_branch.is_none() && project_type.is_none() {
+    if name.is_none() && template.is_none() && branch.is_none() && project_type.is_none() {
         wrangler.arg("generate").assert().success();
-    } else if name.is_some()
-        && template.is_some()
-        && template_branch.is_none()
-        && project_type.is_none()
-    {
+    } else if name.is_some() && template.is_some() && branch.is_none() && project_type.is_none() {
         wrangler
             .arg("generate")
             .arg(name.unwrap())
             .arg(template.unwrap())
             .assert()
             .success();
-    } else if name.is_some()
-        && template.is_some()
-        && template_branch.is_some()
-        && project_type.is_some()
-    {
+    } else if name.is_some() && template.is_some() && branch.is_some() && project_type.is_some() {
         wrangler
             .arg("generate")
             .arg(name.unwrap())
             .arg(template.unwrap())
             .arg("--branch")
-            .arg(template_branch.unwrap())
+            .arg(branch.unwrap())
             .arg("--type")
             .arg(project_type.unwrap())
             .assert()

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -17,10 +17,26 @@ fn it_generates_with_defaults() {
 }
 
 #[test]
-fn it_generates_with_arguments() {
-    let name = "example";
+fn it_generates_with_some_arguments() {
+    let name = "example-rust";
     let template = "https://github.com/cloudflare/rustwasm-worker-template";
-    let template_branch = "master";
+
+    generate(Some(name), Some(template), None, None);
+
+    assert_eq!(Path::new(name).exists(), true);
+
+    let wranglertoml_path = format!("{}/wrangler.toml", name);
+    assert_eq!(Path::new(&wranglertoml_path).exists(), true);
+    let wranglertoml_text = fs::read_to_string(wranglertoml_path).unwrap();
+    assert!(wranglertoml_text.contains("type = \"rust\""));
+    cleanup(name);
+}
+
+#[test]
+fn it_generates_with_all_arguments() {
+    let name = "example-branch";
+    let template = "p-j/worker-eapi-template";
+    let template_branch = "main";
     let project_type = "webpack";
     generate(
         Some(name),
@@ -47,6 +63,17 @@ pub fn generate(
     let mut wrangler = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
     if name.is_none() && template.is_none() && template_branch.is_none() && project_type.is_none() {
         wrangler.arg("generate").assert().success();
+    } else if name.is_some()
+        && template.is_some()
+        && template_branch.is_none()
+        && project_type.is_none()
+    {
+        wrangler
+            .arg("generate")
+            .arg(name.unwrap())
+            .arg(template.unwrap())
+            .assert()
+            .success();
     } else if name.is_some()
         && template.is_some()
         && template_branch.is_some()


### PR DESCRIPTION
## What this PR does:
- introduce a `branch` param to the `generate` command to select a branch on the template used
- branch param defaults to master
- branch param is passed down to cargo_generate

## Context:
- Github default branch has switched from `master` to `main`
- I've recently created a template here [`p-j/worker-eapi-template`](https://github.com/p-j/worker-eapi-template)
I can't install with the current version of `wrangler generate` since the default branch is `main` and not `master`: 
I'm getting the following error from `cargo_generate` : **Git Error: failed to find branch `master`**
- `cargo_generate` can take in a `branch` param, which is what this PR use.

## Outcome:
Once build & installed, I can successfully run 
- `wrangler generate test-worker`
- `wrangler generate my-ts-project https://github.com/p-j/worker-eapi-template --branch=main`
- `wrangler generate my-ts-project p-j/worker-eapi-template --branch=main` thanks to the upgrade of cargo_generate to 0.5.1

It's my first time ever writing some rust so do let me know if I'm not doing things correctly 👨‍🎓 