### PR TITLE
Add support for Linux arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ env:
   WINDOWS_TARGET: x86_64-pc-windows-msvc
   MACOS_TARGET: x86_64-apple-darwin
   LINUX_TARGET: x86_64-unknown-linux-musl
+  LINUX_ARM64_TARGET: aarch64-unknown-linux-musl
 
   # Space separated paths to include in the archive.
   RELEASE_ADDS: README.md
@@ -22,9 +23,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [linux, macos, windows, wranglerjs]
+        build: [linux, linux_arm64, macos, windows, wranglerjs]
         include:
           - build: linux
+            os: ubuntu-latest
+            rust: stable
+          - build: linux_arm64
             os: ubuntu-latest
             rust: stable
           - build: macos
@@ -67,6 +71,12 @@ jobs:
         run: |
           rustup target add ${{ env.LINUX_TARGET }}
           cargo build --release --target ${{ env.LINUX_TARGET }}
+      
+      - name: Build (Linux arm64)
+        if: matrix.build == 'linux_arm64'
+        run: |
+          rustup target add ${{ env.LINUX_ARM64_TARGET }}
+          cargo build --release --target ${{ env.LINUX_ARM64_TARGET }}
 
       - name: Build (MacOS)
         if: matrix.build == 'macos'
@@ -89,6 +99,13 @@ jobs:
           mv ./target/${{ env.LINUX_TARGET }}/release/${{ env.RELEASE_BIN }} ./dist/${{ env.RELEASE_BIN }}
           mv ${{ env.RELEASE_ADDS }} ./dist
           7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz
+
+      - name: Create tarball (Linux arm64)
+        if: matrix.build == 'linux_arm64'
+        run: |
+          mv ./target/${{ env.LINUX_ARM64_TARGET }}/release/${{ env.RELEASE_BIN }} ./dist/${{ env.RELEASE_BIN }}
+          mv ${{ env.RELEASE_ADDS }} ./dist
+          7z a -ttar -so -an ./dist | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_ARM64_TARGET }}.tar.gz
 
       - name: Create tarball (Windows)
         if: matrix.build == 'windows'
@@ -146,6 +163,11 @@ jobs:
         with:
           name: linux
 
+      - name: Download Linux arm64 tarball
+        uses: actions/download-artifact@v1
+        with:
+          name: linux_arm64
+
       - name: Download Windows tarball
         uses: actions/download-artifact@v1
         with:
@@ -175,6 +197,16 @@ jobs:
           asset_path: ./linux/wrangler-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz
           asset_content_type: application/gzip
           asset_name: wrangler-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_TARGET }}.tar.gz
+
+      - name: Release Linux arm64 tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./linux_arm64/wrangler-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_ARM64_TARGET }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: wrangler-${{ steps.get_version.outputs.VERSION }}-${{ env.LINUX_ARM64_TARGET }}.tar.gz
 
       - name: Release Windows tarball
         uses: actions/upload-release-asset@v1

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -12,6 +12,9 @@ const getPlatform = () => {
   if (type === "Linux" && arch === "x64") {
     return "x86_64-unknown-linux-musl";
   }
+  if (type === "Linux" && arch === "arm64") {
+    return "aarch64-unknown-linux-musl"
+  }
   if (type === "Darwin" && (arch === "x64" || arch == "arm64")) {
     // for users of M1 / Apple Silicon devices, use an x86 binary automatically run by Rosetta 2.
     return "x86_64-apple-darwin";


### PR DESCRIPTION
cfsetup on an M1 MacBook runs builds in an arm64 container, so in order
to run wrangler in cfsetup on M1 there needs to be an arm64 wrangler
binary.