### PR TITLE
remove toml-rs in favor of using toml_edit and updated toml_edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,13 +2761,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.2.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbdcf4f749dd33b1f1ea19b547bf789d87442ec40767d6015e5e2d39158d69a"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
- "chrono",
  "combine",
- "linked-hash-map",
+ "indexmap",
+ "itertools",
+ "serde",
 ]
 
 [[package]]
@@ -3232,7 +3233,6 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",
- "toml",
  "toml_edit",
  "twox-hash",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,7 @@ tokio-retry = "0.3"
 tokio-rustls = "0.23.0"
 tokio-stream = "0.1.5"
 tokio-tungstenite = "0.14.0"
-toml = "0.5.8"
-toml_edit = "0.2.0"
+toml_edit = { version = "0.14.4", features = ["easy"] }
 twox-hash = "1.6.0"
 url = "2.2.0"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/settings/global_user.rs
+++ b/src/settings/global_user.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use cloudflare::framework::auth::Credentials;
 use serde::{Deserialize, Serialize};
+use toml_edit::easy as toml;
 
 use crate::login::check_update_oauth_token;
 use crate::settings::{get_global_config_path, Environment, QueryEnvironment};

--- a/src/settings/toml/manifest.rs
+++ b/src/settings/toml/manifest.rs
@@ -11,6 +11,7 @@ use chrono::Utc;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_with::rust::string_empty_as_none;
+use toml_edit::easy as toml;
 
 use super::migrations::{MigrationConfig, MigrationTag, Migrations};
 use super::UsageModel;
@@ -161,14 +162,14 @@ impl Manifest {
                 if let Some(include) = &site.include {
                     let mut arr = toml_edit::Array::default();
                     include.iter().for_each(|i| {
-                        arr.push(i.as_ref()).unwrap();
+                        arr.push(i);
                     });
                     config_template_doc["site"]["include"] = toml_edit::value(arr);
                 }
                 if let Some(exclude) = &site.exclude {
                     let mut arr = toml_edit::Array::default();
                     exclude.iter().for_each(|i| {
-                        arr.push(i.as_ref()).unwrap();
+                        arr.push(i);
                     });
                     config_template_doc["site"]["exclude"] = toml_edit::value(arr);
                 }
@@ -180,7 +181,7 @@ impl Manifest {
 
         // TODO: https://github.com/cloudflare/wrangler/issues/773
 
-        let toml = config_template_doc.to_string_in_original_order();
+        let toml = config_template_doc.to_string();
         let manifest = toml::from_str::<Manifest>(&toml)?;
 
         log::info!("Writing a wrangler.toml file at {}", config_file.display());

--- a/src/settings/toml/tests/deployments.rs
+++ b/src/settings/toml/tests/deployments.rs
@@ -1,5 +1,7 @@
 use std::str::FromStr;
 
+use toml_edit::easy as toml;
+
 use crate::deploy::{DeployTarget, ScheduleTarget, ZonedTarget, ZonelessTarget};
 use crate::settings::toml::route::Route;
 use crate::settings::toml::Manifest;

--- a/src/settings/toml/tests/mod.rs
+++ b/src/settings/toml/tests/mod.rs
@@ -7,6 +7,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use toml_edit::easy as toml;
+
 #[path = "../../../../tests/fixtures/mod.rs"]
 mod fixtures;
 use fixtures::{EnvConfig, WranglerToml, TEST_ENV_NAME};

--- a/src/upload/krate.rs
+++ b/src/upload/krate.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use serde::{self, Deserialize};
+use toml_edit::easy as toml;
 
 #[derive(Debug, Deserialize)]
 pub struct Krate {

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use reqwest::header::USER_AGENT;
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use toml_edit::easy as toml;
 
 const ONE_DAY: u64 = 60 * 60 * 24;
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -5,6 +5,7 @@ use std::str;
 use assert_cmd::prelude::*;
 mod fixtures;
 use fixtures::{Fixture, WranglerToml};
+use toml_edit::easy as toml;
 
 #[test]
 fn it_builds_webpack() {

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 use std::thread;
 
 use tempfile::TempDir;
+use toml_edit::easy as toml;
 
 const BUNDLE_OUT: &str = "worker";
 


### PR DESCRIPTION
toml-rs is unmaintained and most development has gone towards toml_edit. 
To use toml_edit, the "easy" feature had to be enabled and the version had to be bumped. 

because of the version bump, `to_string_in_original_order()`[[ref]](https://github.com/ordian/toml_edit/pull/148) to be changed to `to_string()` as it's now the default behavior of the Display trait implementation.

